### PR TITLE
Adds alignment property

### DIFF
--- a/lib/dotted_line.dart
+++ b/lib/dotted_line.dart
@@ -33,6 +33,7 @@ class DottedLine extends StatelessWidget {
     this.dashGapGradient,
     this.dashRadius = 0.0,
     this.dashGapRadius = 0.0,
+    this.alignment = WrapAlignment.center,
   })  : assert(
             dashGradient == null || dashGradient.length == 2,
             'The dashGradient must have only two colors.\n'
@@ -45,6 +46,9 @@ class DottedLine extends StatelessWidget {
 
   /// The direction of the entire dotted line. Default [Axis.horizontal].
   final Axis direction;
+
+  /// The alignment of the entire dotted line. Default [WrapAlignment.center].
+  final WrapAlignment alignment;
 
   /// The length of the entire dotted line. Default [double.infinity].
   final double lineLength;
@@ -101,6 +105,7 @@ class DottedLine extends StatelessWidget {
 
         return Wrap(
           direction: direction,
+          alignment: alignment,
           children: List.generate(dashCount + dashGapCount, (index) {
             if (index % 2 == 0) {
               final dashColor = _getDashColor(dashCount, index ~/ 2);


### PR DESCRIPTION
In some cases, the dashed line would have an offset to the side, which in return wouldn't be as pleasant to look at in comparison to the divider, since it is this widget that hopefully this package is trying to replace to.

So, by adding a property `alignment`, defaulted to `WrapAlignment.center`, one can achieve the desired alignment inside its application. If needed, this can be later changed by the developer to adjust for his/her scenario.

This may close the issue #25 - Feature: option to specify alignment.