### PR TITLE
perf: improve performance by adding RepaintBoundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This package allows you to draw dotted lines with Flutter.
 | **dashGapColor**    |  Colors.transparent  |               The color of the dash gap. |
 | **dashGapGradient** |         null         |     The gradient colors of the dash gap. |
 | **dashGapRadius**   |         0.0          |              The radius of the dash gap. |
+| **addRepaintBoundary**|       false        | Whether to wrap the dotted line with a RepaintBoundary. |
 
 This can be used without parameters.
 
@@ -51,8 +52,16 @@ DottedLine(
   dashGapColor: Colors.transparent,
   dashGapGradient: [Colors.red, Colors.blue],
   dashGapRadius: 0.0,
+  addRepaintBoundary: true,
 )
 ```
+
+# Performance Optimization
+If your DottedLine is placed inside a widget that rebuilds frequently, you might experience performance issues (dropped frames) because the dashes and gaps are constantly repainted.
+
+In such cases, setting addRepaintBoundary: true can improve performance by wrapping the DottedLine in a RepaintBoundary, isolating its paint step.
+
+Note: The default is false to prevent unexpected memory overhead. Keep it false if you are displaying hundreds of dotted lines (e.g., in a large list) to avoid excessive memory usage.
 
 # Example
 The sample code can be found under the `example` package.

--- a/lib/dotted_line.dart
+++ b/lib/dotted_line.dart
@@ -95,31 +95,33 @@ class DottedLine extends StatelessWidget {
   Widget build(BuildContext context) {
     final isHorizontal = direction == Axis.horizontal;
 
-    return SizedBox(
-      width: isHorizontal ? lineLength : lineThickness,
-      height: isHorizontal ? lineThickness : lineLength,
-      child: LayoutBuilder(builder: (context, constraints) {
-        final lineLength = _getLineLength(constraints, isHorizontal);
-        final dashAndDashGapCount = _calculateDashAndDashGapCount(lineLength);
-        final dashCount = dashAndDashGapCount[0];
-        final dashGapCount = dashAndDashGapCount[1];
+    return RepaintBoundary(
+      child: SizedBox(
+        width: isHorizontal ? lineLength : lineThickness,
+        height: isHorizontal ? lineThickness : lineLength,
+        child: LayoutBuilder(builder: (context, constraints) {
+          final lineLength = _getLineLength(constraints, isHorizontal);
+          final dashAndDashGapCount = _calculateDashAndDashGapCount(lineLength);
+          final dashCount = dashAndDashGapCount[0];
+          final dashGapCount = dashAndDashGapCount[1];
 
-        return Wrap(
-          direction: direction,
-          alignment: alignment,
-          children: List.generate(dashCount + dashGapCount, (index) {
-            if (index % 2 == 0) {
-              final dashColor = _getDashColor(dashCount, index ~/ 2);
-              final dash = _buildDash(isHorizontal, dashColor);
-              return dash;
-            } else {
-              final dashGapColor = _getDashGapColor(dashGapCount, index ~/ 2);
-              final dashGap = _buildDashGap(isHorizontal, dashGapColor);
-              return dashGap;
-            }
-          }).toList(growable: false),
-        );
-      }),
+          return Wrap(
+            direction: direction,
+            alignment: alignment,
+            children: List.generate(dashCount + dashGapCount, (index) {
+              if (index % 2 == 0) {
+                final dashColor = _getDashColor(dashCount, index ~/ 2);
+                final dash = _buildDash(isHorizontal, dashColor);
+                return dash;
+              } else {
+                final dashGapColor = _getDashGapColor(dashGapCount, index ~/ 2);
+                final dashGap = _buildDashGap(isHorizontal, dashGapColor);
+                return dashGap;
+              }
+            }).toList(growable: false),
+          );
+        }),
+      ),
     );
   }
 

--- a/lib/dotted_line.dart
+++ b/lib/dotted_line.dart
@@ -19,6 +19,8 @@ import 'package:flutter/material.dart';
 /// * [dashGapColor]
 /// * [dashGapRadius]
 /// * [dashGapGradient]
+/// performance settings
+/// * [addRepaintBoundary]
 class DottedLine extends StatelessWidget {
   /// Creates dotted line with the given parameters
   const DottedLine({
@@ -35,6 +37,7 @@ class DottedLine extends StatelessWidget {
     this.dashGapGradient,
     this.dashRadius = 0.0,
     this.dashGapRadius = 0.0,
+    this.addRepaintBoundary = false,
   })  : assert(
             dashGradient == null || dashGradient.length == 2,
             'The dashGradient must have only two colors.\n'
@@ -91,38 +94,43 @@ class DottedLine extends StatelessWidget {
   /// The radius of the dash gap. Default (0.0).
   final double dashGapRadius;
 
+  /// Whether to add [RepaintBoundary] to the entire dotted line. Default false.
+  final bool addRepaintBoundary;
+
   @override
   Widget build(BuildContext context) {
     final isHorizontal = direction == Axis.horizontal;
 
-    return RepaintBoundary(
-      child: SizedBox(
-        width: isHorizontal ? lineLength : lineThickness,
-        height: isHorizontal ? lineThickness : lineLength,
-        child: LayoutBuilder(builder: (context, constraints) {
-          final lineLength = _getLineLength(constraints, isHorizontal);
-          final dashAndDashGapCount = _calculateDashAndDashGapCount(lineLength);
-          final dashCount = dashAndDashGapCount[0];
-          final dashGapCount = dashAndDashGapCount[1];
+    Widget content = SizedBox(
+      width: isHorizontal ? lineLength : lineThickness,
+      height: isHorizontal ? lineThickness : lineLength,
+      child: LayoutBuilder(builder: (context, constraints) {
+        final lineLength = _getLineLength(constraints, isHorizontal);
+        final dashAndDashGapCount = _calculateDashAndDashGapCount(lineLength);
+        final dashCount = dashAndDashGapCount[0];
+        final dashGapCount = dashAndDashGapCount[1];
 
-          return Wrap(
-            direction: direction,
-            alignment: alignment,
-            children: List.generate(dashCount + dashGapCount, (index) {
-              if (index % 2 == 0) {
-                final dashColor = _getDashColor(dashCount, index ~/ 2);
-                final dash = _buildDash(isHorizontal, dashColor);
-                return dash;
-              } else {
-                final dashGapColor = _getDashGapColor(dashGapCount, index ~/ 2);
-                final dashGap = _buildDashGap(isHorizontal, dashGapColor);
-                return dashGap;
-              }
-            }).toList(growable: false),
-          );
-        }),
-      ),
+        return Wrap(
+          direction: direction,
+          alignment: alignment,
+          children: List.generate(dashCount + dashGapCount, (index) {
+            if (index % 2 == 0) {
+              final dashColor = _getDashColor(dashCount, index ~/ 2);
+              final dash = _buildDash(isHorizontal, dashColor);
+              return dash;
+            } else {
+              final dashGapColor = _getDashGapColor(dashGapCount, index ~/ 2);
+              final dashGap = _buildDashGap(isHorizontal, dashGapColor);
+              return dashGap;
+            }
+          }).toList(growable: false),
+        );
+      }),
     );
+    if (addRepaintBoundary) {
+      content = RepaintBoundary(child: content);
+    }
+    return content;
   }
 
   /// If [lineLength] is [double.infinity],


### PR DESCRIPTION
## Description
Resolves #61


As discussed in the issue, this PR introduces a `RepaintBoundary` at the root of the `DottedLine` widget. 

### Why this change?
Currently, `DottedLine` creates many small `Container` widgets. When the parent widget rebuilds, these are all repainted even if they haven't changed. By adding a `RepaintBoundary`, we can:
- Isolate the painting of the dotted line.
- Reduce GPU overhead during parent rebuilds.
- Eliminate jank (dropped frames) in complex lists or animated screens.

### Changes
- Wrapped the main `Wrap` widget (or the root container) in `DottedLine` with a `RepaintBoundary`.

### Verification
I have verified the performance improvement using the reproduction code provided in the issue. The "orange bars" in Flutter DevTools Performance overlay are significantly reduced after this change.

Thank you for your review, and congratulations on the new addition to your family! 👶✨