### PR TITLE
release/v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.3.0
+
+* Add `addRepaintBoundary` parameter to optionally wrap the dotted line with a `RepaintBoundary` for paint isolation. Default is `false`.
+  * https://github.com/umechanhika/dotted_line/pull/62
+  * https://github.com/umechanhika/dotted_line/issues/61
+* Widen the Dart SDK constraint to `>=2.12.0 <4.0.0` to support Dart 3.
+* Replace the deprecated per-channel `Color` API in gradient calculation with `Color.lerp` to fix static analysis warnings.
+* Fix the `ruby-version` setting in the Pre-release check workflow.
+
+Thanks to @mem-5514-tahara for this release!
+
 ## 3.2.3
 
 * Modify .github/workflows/check.yml, Gemfile & Gemfile.lock.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dotted_line
 description: This package allows you to draw dotted lines with Flutter. You can draw a beautiful dotted line.
-version: 3.2.3
+version: 3.3.0
 homepage: https://github.com/umechanhika/dotted_line
 repository: https://github.com/umechanhika/dotted_line
 


### PR DESCRIPTION
## Release v3.3.0

Bump version to `3.3.0` and update CHANGELOG for the next pub.dev release.

### Included
- #62 — Add `addRepaintBoundary` parameter for optional paint isolation (Resolves #61). Thanks to @mem-5514-tahara!

### After merge
- Tag `v3.3.0` on `master` to trigger automatic publish to pub.dev (`.github/workflows/publish.yml`).