### PR TITLE
fix: repair Pre-release check CI and widen Dart SDK constraint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0'
 
       - name: Danger
         env:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/umechanhika/dotted_line
 repository: https://github.com/umechanhika/dotted_line
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
Fixes the failing **Pre-release check** (Danger) workflow and widens the Dart SDK constraint so the package supports Dart 3.

### 1. CI failure fix (`.github/workflows/check.yml`)
`ruby-version: 3.0` was **unquoted**, so YAML parsed it as the float `3.0` → `"3"`, and `ruby/setup-ruby` resolved it to the latest Ruby 3.x (3.4.9). That Ruby is incompatible with the `bundler 2.1.0` pinned in `Gemfile.lock` (it references `DidYouMean::SPELL_CHECKERS`, removed in Ruby 3.1+), so `bundle install` crashed before Danger could run.

Quoting it (`'3.0'`) pins Ruby 3.0.x, which is compatible with the locked bundler/gems.

### 2. Dart 3 support (`pubspec.yaml`)
Widened the SDK upper bound from `<3.0.0` to `<4.0.0` so the package can be resolved on Dart 3 toolchains.

### Note
Merge this to `master` first; the `release/v3.3.0` PR (#63) will then be merged on top and tagged for the pub.dev release.