### PR TITLE
fix: resolve pub.dev publish warning (checked-in but gitignored lockfiles)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Miscellaneous
 *.class
 *.lock
+# These lock files are intentionally checked in; un-ignore them so they are
+# not flagged as "checked-in but gitignored" when publishing to pub.dev.
+# They are excluded from the published package via .pubignore instead.
+!Gemfile.lock
+!/example/pubspec.lock
 *.log
 *.pyc
 *.swp

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,4 @@
+# Files tracked in git but not part of the published Dart package.
+# (They are matched by .gitignore, which pub warns about otherwise.)
+/Gemfile.lock
+/example/pubspec.lock

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,6 +1,9 @@
 # Miscellaneous
 *.class
 *.lock
+# pubspec.lock is intentionally checked in for this example app; un-ignore it
+# so it is not flagged when publishing the parent package to pub.dev.
+!pubspec.lock
 *.log
 *.pyc
 *.swp


### PR DESCRIPTION
## Summary
Makes `dart pub publish` warning-free so the v3.3.0 release publishes cleanly.

### Problem
The `*.lock` rule in `.gitignore` (and `example/.gitignore`) matches the **checked-in** `Gemfile.lock` and `example/pubspec.lock`. pub flags these as "checked-in files ignored by a `.gitignore`", producing a warning. `dart pub publish --dry-run` exits non-zero on warnings (though the real job uses `--force`, which would publish anyway).

### Fix
- Un-ignore the two tracked lockfiles in `.gitignore` / `example/.gitignore` so the git state is consistent (they stay tracked for CI reproducibility).
- Add a `.pubignore` to exclude them from the published package archive.

### Verification
Ran the real publish environment in CI via a temporary `dart pub publish --dry-run` job (matching `publish.yml`): **Package has 0 warnings.**

### Note
Merge before tagging `v3.3.0`.